### PR TITLE
Update publish_site.yml

### DIFF
--- a/.github/workflows/build_site_for_review.yml
+++ b/.github/workflows/build_site_for_review.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install tools
         run: |
+          sudo apt-get update
           sudo apt install -y pandoc libxml2-dev libssl-dev libcurl4-openssl-dev r-base r-base-dev;
           sudo apt install -y libharfbuzz-dev libfribidi-dev;
           sudo R -e "install.packages('devtools')";

--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install tools
         run: |
+          sudo apt-get update
           sudo apt install -y pandoc libxml2-dev libssl-dev libcurl4-openssl-dev r-base r-base-dev;
           sudo apt install -y libharfbuzz-dev libfribidi-dev;
           sudo R -e "install.packages('devtools')";


### PR DESCRIPTION
There are problems with libcurl4-openssl-dev mirrors. As in [1]. Attempt with [2] solution.
[1] https://github.com/actions/runner-images/issues/5470 
[2] https://github.com/actions/runner-images/issues/3640